### PR TITLE
fix: light and dark theme color adjustments and cta renaming

### DIFF
--- a/app/components/ImageAssets.tsx
+++ b/app/components/ImageAssets.tsx
@@ -496,21 +496,21 @@ export const NoteIcon = (props: ImageProps) => {
       <title>Note icon</title>
       <path
         d="M13.332 7.33398V6.66732C13.332 4.15316 13.332 2.89608 12.505 2.11503C11.678 1.33398 10.347 1.33398 7.68497 1.33398L6.97909 1.33398C4.31704 1.33398 2.98602 1.33398 2.15902 2.11503C1.33203 2.89608 1.33203 4.15316 1.33203 6.66732L1.33203 9.33398C1.33203 11.8481 1.33203 13.1052 2.15902 13.8863C2.98602 14.6673 4.31704 14.6673 6.97909 14.6673H7.33203"
-        stroke="white"
+        stroke="currentColor"
         strokeOpacity="0.3"
         strokeWidth="1.2"
         strokeLinecap="round"
       />
       <path
         d="M4.66406 4.66797H9.9974"
-        stroke="white"
+        stroke="currentColor"
         strokeOpacity="0.3"
         strokeWidth="1.2"
         strokeLinecap="round"
       />
       <path
         d="M4.66406 8H9.9974"
-        stroke="white"
+        stroke="currentColor"
         strokeOpacity="0.3"
         strokeWidth="1.2"
         strokeLinecap="round"
@@ -537,7 +537,7 @@ export const AddUserIcon = (props: ImageProps) => {
       <title>Add user icon</title>
       <path
         d="M8.83203 14.6673H4.89261C3.86236 14.6673 3.0429 14.166 2.30714 13.465C0.800941 12.0301 3.2739 10.8833 4.21708 10.3217C5.61761 9.48777 7.25659 9.18191 8.83203 9.40411C9.4037 9.48474 9.96045 9.6349 10.4987 9.85459"
-        stroke="white"
+        stroke="currentColor"
         strokeOpacity="0.5"
         strokeWidth="1.5"
         strokeLinecap="round"
@@ -545,13 +545,13 @@ export const AddUserIcon = (props: ImageProps) => {
       />
       <path
         d="M11.5 4.33398C11.5 5.99084 10.1569 7.33398 8.5 7.33398C6.84315 7.33398 5.5 5.99084 5.5 4.33398C5.5 2.67713 6.84315 1.33398 8.5 1.33398C10.1569 1.33398 11.5 2.67713 11.5 4.33398Z"
-        stroke="white"
+        stroke="currentColor"
         strokeOpacity="0.5"
         strokeWidth="1.5"
       />
       <path
         d="M12.8333 14.6667L12.8333 10M10.5 12.3333H15.1667"
-        stroke="white"
+        stroke="currentColor"
         strokeOpacity="0.5"
         strokeWidth="1.5"
         strokeLinecap="round"

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -66,7 +66,7 @@ export const Navbar = () => {
                 className={primaryBtnClasses}
                 onClick={login}
               >
-                Connect Wallet
+                Sign In
               </button>
             </>
           )}

--- a/app/components/RecipientDetailsForm.tsx
+++ b/app/components/RecipientDetailsForm.tsx
@@ -358,9 +358,9 @@ export const RecipientDetailsForm = ({
       ) : (
         <Button
           onClick={() => setIsModalOpen(true)}
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-gray-300 bg-transparent px-3 py-2.5 text-sm text-neutral-900 outline-none transition-all hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed dark:border-white/10 dark:text-white/80 dark:hover:bg-white/5 dark:focus-visible:ring-offset-neutral-900"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-gray-300 bg-transparent px-3 py-2.5 text-sm text-black outline-none transition-all hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed dark:border-white/10 dark:text-white dark:hover:bg-white/5 dark:focus-visible:ring-offset-neutral-900"
         >
-          <AddUserIcon className="fill-gray-300 stroke-gray-300 dark:fill-transparent dark:stroke-gray-600" />
+          <AddUserIcon className="text-outline-gray dark:text-white/50" />
           <p>Add recipient</p>
         </Button>
       )}

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -226,7 +226,7 @@ export const TransactionForm = ({
           <VerifyIDModal />
         ) : (
           <button type="button" className={primaryBtnClasses} onClick={login}>
-            Connect
+            Get Started
           </button>
         )}
 

--- a/app/pages/TransactionForm.tsx
+++ b/app/pages/TransactionForm.tsx
@@ -206,7 +206,7 @@ export const TransactionForm = ({
 
           {/* Memo */}
           <div className="relative">
-            <NoteIcon className="absolute left-2 top-2.5 fill-gray-200 stroke-gray-300 dark:fill-transparent dark:stroke-none" />
+            <NoteIcon className="absolute left-2 top-2.5 fill-white stroke-gray-300 dark:fill-transparent dark:stroke-none" />
             <input
               type="text"
               id="memo"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,9 @@ const config: Config = {
         primary: "#8B85F4",
         secondary: "#43B9FB",
         black: "#121217",
+        outline: {
+          gray: "#8A8AA3"
+        }
       },
     },
   },


### PR DESCRIPTION
This PR handles the modification of icons and label color on both light and dark themes on the transaction form. It also handles the renaming of the "Connect" and "Connect Wallet" CTAs to "SIgn In" and "Get Started" respectively.

### Shots
![image](https://github.com/user-attachments/assets/554d774f-27ef-4eb2-8fe3-75de373ec6b4)
![image](https://github.com/user-attachments/assets/5ab3fdf6-a533-4808-ba10-433b93416dff)

